### PR TITLE
Fix: tickNumber props

### DIFF
--- a/src/components/AxisX.svelte
+++ b/src/components/AxisX.svelte
@@ -8,6 +8,7 @@
 	export let baseline = false;
 	export let snapTicks = false;
 	export let ticks = undefined;
+	export let tickNumber = undefined;
 
 	$: tickVals = Array.isArray(ticks) ? ticks : $xScale.ticks(tickNumber);
 

--- a/src/components/AxisY.svelte
+++ b/src/components/AxisY.svelte
@@ -6,6 +6,7 @@
 	export let ticks = undefined;
 	export let gridlines = true;
 	export let formatTick = d => d;
+	export let tickNumber = undefined;
 
 	$: tickVals = Array.isArray(ticks) ? ticks : $yScale.ticks(tickNumber);
 </script>


### PR DESCRIPTION
The default line chart didn't render bececause of these missing props. 