### PR TITLE
New example needs d3-shape to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "clean-css": "^4.2.3",
+    "d3-shape": "^3.0.1",
     "sirv-cli": "^0.4.4"
   }
 }


### PR DESCRIPTION
Noticed d3-shape wasn't in the package.json when I pulled a clean copy of the template to check out the SSR thing.