### PR TITLE
Add type definitions for CSV imports

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -8,6 +8,7 @@ declare global {
 		// interface PageState {}
 		// interface Platform {}
 	}
+	module '*.csv';
 }
 
 export {};

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,0 @@
-/// <reference types="@sveltejs/kit" />
-
-declare module '*.csv';

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="@sveltejs/kit" />
+
+declare module '*.csv';


### PR DESCRIPTION
Fixes `npm run check` error, just copied the file from `layercake` repo:

```
/layercake-template/src/routes/+page.svelte:9:21
Error: Cannot find module './_data/points.csv' or its corresponding type declarations. (js)

	import points from './_data/points.csv';
```